### PR TITLE
Type file ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,27 @@
+import React from 'react'
+
+declare module 'react-hover' {
+    export interface ReactHoverOptions{
+        followCursor: boolean,
+        shiftX: number,
+        shiftY: number
+    }
+
+    export interface ReactHoverProps {
+        options: ReactHoverOptions
+    }
+
+    export interface TriggerProps {
+        type: string
+    }
+
+    export interface HoverProps {
+        type: string
+    }
+
+    export class Trigger extends React.Component<TriggerProps> { }
+    export class Hover extends React.Component<HoverProps> { }
+    export class ReactHover extends React.Component<ReactHoverProps>{ }
+
+    export default ReactHover;
+}


### PR DESCRIPTION
Adding type definition file turn possible using the lib with TypeScript projects and on JavaScript projects also provides a better intellisense for the IDE.

### Why?
When I tried to use this library on a project typescript doesn't allow it because there are no type definition files.

### What this do?
Just created the index.d.ts file and put a simple type definition on it. That was discussed on #44 